### PR TITLE
Add additional Netflix hostnames

### DIFF
--- a/src/var/unbound/etc/netflix.conf
+++ b/src/var/unbound/etc/netflix.conf
@@ -14,6 +14,10 @@ local-data: "prodaa.netflix.com. IN AAAA ::"
 local-data: "ichnaea.netflix.com. IN AAAA ::"
 local-data: "ichnaea.geo.netflix.com. IN AAAA ::"
 local-data: "ichnaea.latency.prodaa.netflix.com. IN AAAA ::"
+local-data: "api-global.netflix.com. IN AAAA ::"
+local-data: "api-global.geo.netflix.com. IN AAAA ::"
+local-data: "api-global.us-east-1.prodaa.netflix.com. IN AAAA ::"
+local-data: "api-global.us-west-2.prodaa.netflix.com. IN AAAA ::"
 
 local-zone: "netflix.net." typetransparent
 local-data: "netflix.net. IN AAAA ::"


### PR DESCRIPTION
Add hostnames required in order for Netflix to work on the Apple TV 4K while using a tunnelbroker.